### PR TITLE
Fix rendering second and following forms

### DIFF
--- a/src/Renderers/Bs3FormRenderer.php
+++ b/src/Renderers/Bs3FormRenderer.php
@@ -42,6 +42,16 @@ class Bs3FormRenderer extends DefaultFormRenderer
 	}
 
 
+	public function render(Form $form, string $mode = null): string
+	{
+		if ($this->form !== $form) {
+			$this->controlsInit = false;
+		}
+
+		return parent::render($form, $mode);
+	}
+
+
 	public function renderBegin(): string
 	{
 		$this->controlsInit();

--- a/src/Renderers/Bs4FormRenderer.php
+++ b/src/Renderers/Bs4FormRenderer.php
@@ -60,6 +60,16 @@ class Bs4FormRenderer extends DefaultFormRenderer
 	}
 
 
+	public function render(Form $form, string $mode = null): string
+	{
+		if ($this->form !== $form) {
+			$this->controlsInit = false;
+		}
+
+		return parent::render($form, $mode);
+	}
+
+
 	public function renderBegin(): string
 	{
 		$this->controlsInit();


### PR DESCRIPTION
Currently, renderers are single use only. If you try to render another form with a same instance, you're out of luck because `FormRenderer::$controlsInit` set to `true` after first render prevents it. 

This does not have to be considered a bug per se and I can imagine this as a desired behaviour. However, both renderers extend `Nette\Forms\Rendering\DefaultFormRenderer` and the parent supports multiple forms to be rendered.