### PR TITLE
Allow installing with Latte 3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
 	],
 	"require": {
 		"php": ">=7.1",
-		"latte/latte": "^2.5",
+		"latte/latte": "^2.5 || ^3.0",
 		"nette/forms": "^3.0",
 		"nette/utils": "^3.0"
 	},

--- a/composer.json
+++ b/composer.json
@@ -12,18 +12,18 @@
 	],
 	"require": {
 		"php": ">=7.1",
-		"nette/forms": "~3.0",
-		"nette/utils": "~3.0",
-		"latte/latte": "~2.5"
+		"latte/latte": "^2.5",
+		"nette/forms": "^3.0",
+		"nette/utils": "^3.0"
 	},
 	"require-dev": {
-		"nette/application": "~3.0",
-		"nette/bootstrap": "~3.0",
-		"nette/di": "~3.0",
-		"nette/robot-loader": "~3.0",
-		"phpstan/phpstan-nette": "0.12.21",
+		"nette/application": "^3.0",
+		"nette/bootstrap": "^3.0",
+		"nette/di": "^3.0",
+		"nette/robot-loader": "^3.0",
 		"phpstan/phpstan": "0.12.99",
-		"tracy/tracy": "~2.5"
+		"phpstan/phpstan-nette": "0.12.21",
+		"tracy/tracy": "^2.5"
 	},
 	"extra": {
 		"branch-alias": {

--- a/examples/lattemacros/LatteMacrosPresenter.latte
+++ b/examples/lattemacros/LatteMacrosPresenter.latte
@@ -12,9 +12,10 @@
 	<div class="container">
 		<h1>Form LatteMacros rendering</h1>
 		<hr>
+		<p class="alert alert-danger" n:if="version_compare(\Latte\Engine::VERSION, '3', '>=')">The macros are currently only supported on Latte 2.</p>
 		{form form class => form-horizontal}
 		<div class="form-group">
-			{label text class => "label-control col-sm-3"}
+			{label text class => "label-control col-sm-3" /}
 			<div class="col-sm-9">{input text}{inputError text}</div>
 		</div>
 		<div class="form-group">
@@ -27,35 +28,35 @@
 		</div>
 
 		<div class="form-group">
-			{label checkbox_list class => "label-control col-sm-3"}
+			{label checkbox_list class => "label-control col-sm-3" /}
 			<div class="col-sm-9">{input checkbox_list}{inputError checkbox_list}</div>
 		</div>
 		<div class="form-group">
-			{label integer class => "label-control col-sm-3"}
+			{label integer class => "label-control col-sm-3" /}
 			<div class="col-sm-9">{input integer}{inputError integer}</div>
 		</div>
 		<div class="form-group">
-			{label multi_select class => "label-control col-sm-3"}
+			{label multi_select class => "label-control col-sm-3" /}
 			<div class="col-sm-9">{input multi_select}{inputError multi_select}</div>
 		</div>
 		<div class="form-group">
-			{label password class => "label-control col-sm-3"}
+			{label password class => "label-control col-sm-3" /}
 			<div class="col-sm-9">{input password}{inputError password}</div>
 		</div>
 		<div class="form-group">
-			{label radio_list class => "label-control col-sm-3"}
+			{label radio_list class => "label-control col-sm-3" /}
 			<div class="col-sm-9">{input radio_list}{inputError radio_list}</div>
 		</div>
 		<div class="form-group">
-			{label select class => "label-control col-sm-3"}
+			{label select class => "label-control col-sm-3" /}
 			<div class="col-sm-9">{input select}{inputError select}</div>
 		</div>
 		<div class="form-group">
-			{label textarea class => "label-control col-sm-3"}
+			{label textarea class => "label-control col-sm-3" /}
 			<div class="col-sm-9">{input textarea}{inputError textarea}</div>
 		</div>
 		<div class="form-group">
-			{label multi_upload class => "label-control col-sm-3"}
+			{label multi_upload class => "label-control col-sm-3" /}
 			<div class="col-sm-9">{input multi_upload}{inputError multi_upload}</div>
 		</div>
 		<div class="form-group">

--- a/readme.md
+++ b/readme.md
@@ -12,7 +12,7 @@ Form renderers:
 - *Bs4Renderer* - renderer for Bootstrap 4 with support for horizontal, vertial and inline mode;
 - *Bs5Renderer* - renderer for Bootstrap 5 with support for horizontal, vertial and inline mode;
 
-Latte Macros renderers:
+Latte Macros renderers (only for Latte 2):
 - *Bs3InputMacros* - modifies Form Macros to add Bootstrap 3 classes automatically;
 
 ### Installation
@@ -23,7 +23,7 @@ The best way to install is using [Composer](http://getcomposer.org/):
 $ composer require nextras/forms-rendering
 ```
 
-Register Bs3InputMacros using Nette DI config:
+Register Bs3InputMacros using Nette DI config (only for Latte 2):
 
 ```yaml
 latte:

--- a/src/LatteMacros/BaseInputMacros.php
+++ b/src/LatteMacros/BaseInputMacros.php
@@ -19,6 +19,13 @@ use Nette\Utils\Html;
 use Nextras;
 
 
+/**
+ * Latte macros for Nette\Forms.
+ * Latte v2 macros for Nette\Forms.
+ *
+ * - {input name}
+ * - {label name /} or {label name}... {/label}
+ */
 abstract class BaseInputMacros extends MacroSet
 {
 	/**


### PR DESCRIPTION
This relaxes the version bounds so that people can continue to use the renderers after upgrading to Latte 3.

I did not really bother fixing the latte macros themselves as they do not really seem to be maintained, only supporting Bootstrap 3. The existing `latte.macros` config key will just be a no-op with Latte 3, so Latte will just switch to the default macro definitions from Nette Forms.
