### PR TITLE
Fix Input Macros

### DIFF
--- a/examples/lattemacros/LatteMacrosPresenter.latte
+++ b/examples/lattemacros/LatteMacrosPresenter.latte
@@ -14,54 +14,54 @@
 		<hr>
 		{form form class => form-horizontal}
 		<div class="form-group">
-			{label text class => "label-control col-sm-3" /}
-			<div class="col-sm-9">{input text}{inputError text}</div>
+			{bsLabel text class => "label-control col-sm-3" /}
+			<div class="col-sm-9">{bsInput text}{inputError text}</div>
 		</div>
 		<div class="form-group">
 			<div class="col-sm-9 col-sm-offset-3">
 				<div class="checkbox">
-				{label checkbox}{input checkbox}{/label}
+				{bsLabel checkbox}{bsInput checkbox}{/bsLabel}
 				</div>
 				{inputError checkbox}
 			</div>
 		</div>
 
 		<div class="form-group">
-			{label checkbox_list class => "label-control col-sm-3" /}
-			<div class="col-sm-9">{input checkbox_list}{inputError checkbox_list}</div>
+			{bsLabel checkbox_list class => "label-control col-sm-3" /}
+			<div class="col-sm-9">{bsInput checkbox_list}{inputError checkbox_list}</div>
 		</div>
 		<div class="form-group">
-			{label integer class => "label-control col-sm-3" /}
-			<div class="col-sm-9">{input integer}{inputError integer}</div>
+			{bsLabel integer class => "label-control col-sm-3" /}
+			<div class="col-sm-9">{bsInput integer}{inputError integer}</div>
 		</div>
 		<div class="form-group">
-			{label multi_select class => "label-control col-sm-3" /}
-			<div class="col-sm-9">{input multi_select}{inputError multi_select}</div>
+			{bsLabel multi_select class => "label-control col-sm-3" /}
+			<div class="col-sm-9">{bsInput multi_select}{inputError multi_select}</div>
 		</div>
 		<div class="form-group">
-			{label password class => "label-control col-sm-3" /}
-			<div class="col-sm-9">{input password}{inputError password}</div>
+			{bsLabel password class => "label-control col-sm-3" /}
+			<div class="col-sm-9">{bsInput password}{inputError password}</div>
 		</div>
 		<div class="form-group">
-			{label radio_list class => "label-control col-sm-3" /}
-			<div class="col-sm-9">{input radio_list}{inputError radio_list}</div>
+			{bsLabel radio_list class => "label-control col-sm-3" /}
+			<div class="col-sm-9">{bsInput radio_list}{inputError radio_list}</div>
 		</div>
 		<div class="form-group">
-			{label select class => "label-control col-sm-3" /}
-			<div class="col-sm-9">{input select}{inputError select}</div>
+			{bsLabel select class => "label-control col-sm-3" /}
+			<div class="col-sm-9">{bsInput select}{inputError select}</div>
 		</div>
 		<div class="form-group">
-			{label textarea class => "label-control col-sm-3" /}
-			<div class="col-sm-9">{input textarea}{inputError textarea}</div>
+			{bsLabel textarea class => "label-control col-sm-3" /}
+			<div class="col-sm-9">{bsInput textarea}{inputError textarea}</div>
 		</div>
 		<div class="form-group">
-			{label multi_upload class => "label-control col-sm-3" /}
-			<div class="col-sm-9">{input multi_upload}{inputError multi_upload}</div>
+			{bsLabel multi_upload class => "label-control col-sm-3" /}
+			<div class="col-sm-9">{bsInput multi_upload}{inputError multi_upload}</div>
 		</div>
 		<div class="form-group">
 			<div class="col-sm-9 col-sm-offset-3">
-				{input save class => btn-primary}&nbsp;
-				{input secondary class => btn-default}
+				{bsInput save class => btn-primary}&nbsp;
+				{bsInput secondary class => btn-default}
 			</div>
 		</div>
 		{/form}

--- a/examples/lattemacros/config.neon
+++ b/examples/lattemacros/config.neon
@@ -4,8 +4,9 @@ application:
 		*: NextrasDemos\FormsRendering\LatteMacros\*Module\*Presenter
 
 latte:
-	macros:
-		- Nextras\FormsRendering\LatteMacros\Bs3InputMacros::install
+	extensions:
+		- Nextras\FormsRendering\LatteTags\Bs3\Bs3FormsExtension
+
 
 services:
 	routing.router: Nette\Application\Routers\SimpleRouter('LatteMacros:default')

--- a/src/LatteTags/Bs3/Bs3FormsExtension.php
+++ b/src/LatteTags/Bs3/Bs3FormsExtension.php
@@ -17,8 +17,8 @@ class Bs3FormsExtension extends Extension
 	public function getTags(): array
 	{
 		return [
-			'label' => [Bs3LabelNode::class, 'create'],
-			'input' => [Bs3InputNode::class, 'create'],
+			'bsLabel' => [Bs3LabelNode::class, 'create'],
+			'bsInput' => [Bs3InputNode::class, 'create'],
 		];
 	}
 }

--- a/src/LatteTags/InputNode.php
+++ b/src/LatteTags/InputNode.php
@@ -20,16 +20,16 @@ abstract class InputNode extends NetteInputNode
 {
 	public function print(PrintContext $context): string
 	{
-		$class = get_class();
+		$class = static::class;
 		return $context->format(
 			($this->name instanceof StringNode
 				? '$ʟ_input = end($this->global->formsStack)[%node]; echo ' . $class . '::input($ʟ_input->'
 				: '$ʟ_input = is_object($ʟ_tmp = %node) ? $ʟ_tmp : end($this->global->formsStack)[$ʟ_tmp]; echo ' . $class . '::input($ʟ_input->')
 			. ($this->part ? ('getControlPart(%node)') : 'getControl()')
 			. ($this->attributes->items ? '->addAttributes(%2.node)' : '')
-			. ' %3.line, $ʟ_input, %2.var);',
+			. ' %3.line, $ʟ_input, %1.dump);',
 			$this->name,
-			$this->part,
+			$this->part !== null,
 			$this->attributes,
 			$this->position,
 		);

--- a/src/LatteTags/LabelNode.php
+++ b/src/LatteTags/LabelNode.php
@@ -22,14 +22,14 @@ abstract class LabelNode extends NetteLabelNode
 	{
 		return $context->format(
 			($this->name instanceof StringNode
-				? 'if ($ʟ_label = end($this->global->formsStack)[%node]->'
+				? 'if ($ʟ_label = ($ʟ_input = end($this->global->formsStack)[%node])->'
 				: '$ʟ_input = is_object($ʟ_tmp = %node) ? $ʟ_tmp : end($this->global->formsStack)[$ʟ_tmp]; if ($ʟ_label = $ʟ_input->')
 			. ($this->part ? ('getLabelPart(%node)') : 'getLabel()')
-			. ') echo ' . get_class() . '::label($ʟ_label'
+			. ') echo ' . static::class . '::label($ʟ_label'
 			. ($this->attributes->items ? '->addAttributes(%2.node)' : '')
-			. ($this->void ? ' %3.line, $ʟ_label, %2.var);' : '->startTag() %3.line, $ʟ_label, %2.var); %4.node if ($ʟ_label) echo $ʟ_label->endTag() %5.line;'),
+			. ($this->void ? ' %3.line, $ʟ_input, %1.dump);' : '->startTag() %3.line, $ʟ_input, %1.dump); %4.node if ($ʟ_label) echo $ʟ_label->endTag() %5.line;'),
 			$this->name,
-			$this->part,
+			$this->part !== null,
 			$this->attributes,
 			$this->position,
 			$this->content,


### PR DESCRIPTION
The demo has not been updated to use the new Latte extension so the `input` and `label` macros were picked from `Nette\Bridges\FormsLatte\FormsExtension`. But even if we add our extension the macros from `FormsExtension` will take precedence. Let’s add a prefix.

The template nodes themselves passed incorrect arguments – `.var` is not a thing in Latte 3.

On top of that, an incorrect class name would be used `Nextras\FormsRendering\LatteTags` instead of the Bootstrap 3 specific subclass.