### PR TITLE
PHP 8.4 compatibility

### DIFF
--- a/src/Renderers/Bs3FormRenderer.php
+++ b/src/Renderers/Bs3FormRenderer.php
@@ -42,7 +42,7 @@ class Bs3FormRenderer extends DefaultFormRenderer
 	}
 
 
-	public function render(Form $form, string $mode = null): string
+	public function render(Form $form, ?string $mode = null): string
 	{
 		if (!isset($this->form) || $this->form !== $form) {
 			$this->controlsInit = false;

--- a/src/Renderers/Bs3FormRenderer.php
+++ b/src/Renderers/Bs3FormRenderer.php
@@ -9,7 +9,9 @@
 
 namespace Nextras\FormsRendering\Renderers;
 
+use Nette\Forms\Container;
 use Nette\Forms\Control;
+use Nette\Forms\ControlGroup;
 use Nette\Forms\Controls;
 use Nette\Forms\Form;
 use Nette\Forms\Rendering\DefaultFormRenderer;
@@ -73,6 +75,9 @@ class Bs3FormRenderer extends DefaultFormRenderer
 	}
 
 
+	/**
+	 * @param Container|ControlGroup $parent
+	 */
 	public function renderControls($parent): string
 	{
 		$this->controlsInit();

--- a/src/Renderers/Bs4FormRenderer.php
+++ b/src/Renderers/Bs4FormRenderer.php
@@ -63,7 +63,7 @@ class Bs4FormRenderer extends DefaultFormRenderer
 	}
 
 
-	public function render(Form $form, string $mode = null): string
+	public function render(Form $form, ?string $mode = null): string
 	{
 		if (!isset($this->form) || $this->form !== $form) {
 			$this->controlsInit = false;

--- a/src/Renderers/Bs4FormRenderer.php
+++ b/src/Renderers/Bs4FormRenderer.php
@@ -9,7 +9,9 @@
 
 namespace Nextras\FormsRendering\Renderers;
 
+use Nette\Forms\Container;
 use Nette\Forms\Control;
+use Nette\Forms\ControlGroup;
 use Nette\Forms\Controls;
 use Nette\Forms\Form;
 use Nette\Forms\Rendering\DefaultFormRenderer;
@@ -94,6 +96,9 @@ class Bs4FormRenderer extends DefaultFormRenderer
 	}
 
 
+	/**
+	 * @param Container|ControlGroup $parent
+	 */
 	public function renderControls($parent): string
 	{
 		$this->controlsInit();

--- a/src/Renderers/Bs5FormRenderer.php
+++ b/src/Renderers/Bs5FormRenderer.php
@@ -9,7 +9,9 @@
 
 namespace Nextras\FormsRendering\Renderers;
 
+use Nette\Forms\Container;
 use Nette\Forms\Control;
+use Nette\Forms\ControlGroup;
 use Nette\Forms\Controls;
 use Nette\Forms\Form;
 use Nette\Forms\Rendering\DefaultFormRenderer;
@@ -95,7 +97,9 @@ class Bs5FormRenderer extends DefaultFormRenderer
 		return parent::renderBody();
 	}
 
-
+	/**
+	 * @param Container|ControlGroup $parent
+	 */
 	public function renderControls($parent): string
 	{
 		$this->controlsInit();

--- a/src/Renderers/Bs5FormRenderer.php
+++ b/src/Renderers/Bs5FormRenderer.php
@@ -65,7 +65,7 @@ class Bs5FormRenderer extends DefaultFormRenderer
 	}
 
 
-	public function render(Form $form, string $mode = null): string
+	public function render(Form $form, ?string $mode = null): string
 	{
 		if (!isset($this->form) || $this->form !== $form) {
 			$this->controlsInit = false;


### PR DESCRIPTION
First commit fixes PHP 8.4 deprecation:

> Deprecated in PHP 8.4: Parameter 2 $mode (string) is implicitly nullable via default value null.

Second is "just" PHPStan complaining `renderControls()` methods don't have type specified when using `nette/forms ^3.2`.  The version moved to native union type, however since `nextras/forms-rendering` can be installed with lower versions of `nette/forms`, I just re-specified it in PHPDoc to not break contravariance.