### PR TITLE
Use proper getters for components

### DIFF
--- a/src/Renderers/Bs3FormRenderer.php
+++ b/src/Renderers/Bs3FormRenderer.php
@@ -123,7 +123,7 @@ class Bs3FormRenderer extends DefaultFormRenderer
 		$this->form->getElementPrototype()->addClass('form-horizontal');
 		foreach ($this->form->getControls() as $control) {
 			if ($control instanceof Controls\Button) {
-				$markAsPrimary = $control === $this->primaryButton || (!isset($this->primaryButton) && empty($usedPrimary) && $control->parent instanceof Form);
+				$markAsPrimary = $control === $this->primaryButton || (!isset($this->primaryButton) && empty($usedPrimary) && $control->getParent() instanceof Form);
 				if ($markAsPrimary) {
 					$class = 'btn btn-primary';
 					$usedPrimary = true;

--- a/src/Renderers/Bs4FormRenderer.php
+++ b/src/Renderers/Bs4FormRenderer.php
@@ -152,7 +152,7 @@ class Bs4FormRenderer extends DefaultFormRenderer
 			}
 
 			if ($control instanceof Controls\Button) {
-				$markAsPrimary = $control === $this->primaryButton || (!isset($this->primaryButton) && empty($usedPrimary) && $control->parent instanceof Form);
+				$markAsPrimary = $control === $this->primaryButton || (!isset($this->primaryButton) && empty($usedPrimary) && $control->getParent() instanceof Form);
 				if ($markAsPrimary) {
 					$class = 'btn btn-primary';
 					$usedPrimary = true;

--- a/src/Renderers/Bs5FormRenderer.php
+++ b/src/Renderers/Bs5FormRenderer.php
@@ -176,7 +176,7 @@ class Bs5FormRenderer extends DefaultFormRenderer
 
 			if ($control instanceof Controls\Button) {
 				// Mark first form button (or the one provided) as primary.
-				$markAsPrimary = $control === $this->primaryButton || (!isset($this->primaryButton) && $control->parent instanceof Form);
+				$markAsPrimary = $control === $this->primaryButton || (!isset($this->primaryButton) && $control->getParent() instanceof Form);
 				if ($markAsPrimary) {
 					$class = 'btn btn-primary';
 					$this->primaryButton = $control;


### PR DESCRIPTION
component-model 4.0 removes the use of `Nette\SmartObject` so we can no longer access the private properties:

https://github.com/nette/component-model/commit/c07bbeebfd49149ead63aef7e7750813bade343c
